### PR TITLE
设计优化

### DIFF
--- a/src/main/java/com/topifish/vertx/ssdb/Connection.java
+++ b/src/main/java/com/topifish/vertx/ssdb/Connection.java
@@ -175,12 +175,11 @@ class Connection
 
     private void expandPending()
     {
-        int idx = 0, subIdx;
+        int idx = 0, subIdx = idx;
 
         try {
             while (size > idx) {
                 Queue<byte[]> v = new LinkedList<>();
-                subIdx = idx;
                 while (true) {
                     int nIdx = search(recvBuffer, size, subIdx, CTRL_N);
                     if (nIdx == -1) {

--- a/src/main/java/com/topifish/vertx/ssdb/SSDBClientImpl.java
+++ b/src/main/java/com/topifish/vertx/ssdb/SSDBClientImpl.java
@@ -20,6 +20,7 @@ public class SSDBClientImpl extends CompositeClient
     protected SSDBClientImpl(Vertx vertx, SSDBOptions options)
     {
         super(vertx, options);
+        setAutoClose(false);
     }
 
     @Override

--- a/src/main/java/com/topifish/vertx/ssdb/SSDBPool.java
+++ b/src/main/java/com/topifish/vertx/ssdb/SSDBPool.java
@@ -109,7 +109,7 @@ public class SSDBPool
         SSDBClient client;
         while ((client = queue.poll()) != null) {
             client.setAutoClose(false)
-                  .close(F::succeededFuture);
+                  .close(F.noneHandle());
         }
     }
 }

--- a/src/test/java/ssdb/TestSuite.java
+++ b/src/test/java/ssdb/TestSuite.java
@@ -71,6 +71,7 @@ public class TestSuite
         Async async = testContext.async();
         pool.getClient(event -> {
             SSDBClient client = event.result();
+            client.setAutoClose(false);
             client.dbsize(event1 -> {
                 testContext.assertTrue(event1.succeeded());
                 printf("dbsize : %d", event1.result());


### PR DESCRIPTION
单连接使用时，调用玩api，不自动关闭连接
使用连接池时，默认调用完api之后，返回连接池